### PR TITLE
Add admin toolbar entry for bought products navigation

### DIFF
--- a/Grocery.App/ViewModels/GroceryListViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Grocery.Core.Enums;
 using Grocery.Core.Interfaces.Services;
 using Grocery.Core.Models;
 using System.Collections.ObjectModel;
@@ -10,12 +11,18 @@ namespace Grocery.App.ViewModels
     {
         public ObservableCollection<GroceryList> GroceryLists { get; set; }
         private readonly IGroceryListService _groceryListService;
+        private readonly GlobalViewModel _global;
 
-        public GroceryListViewModel(IGroceryListService groceryListService) 
+        [ObservableProperty]
+        private Client? client;
+
+        public GroceryListViewModel(IGroceryListService groceryListService, GlobalViewModel globalViewModel)
         {
             Title = "Boodschappenlijst";
             _groceryListService = groceryListService;
+            _global = globalViewModel;
             GroceryLists = new(_groceryListService.GetAll());
+            Client = _global.Client;
         }
 
         [RelayCommand]
@@ -24,10 +31,21 @@ namespace Grocery.App.ViewModels
             Dictionary<string, object> paramater = new() { { nameof(GroceryList), groceryList } };
             await Shell.Current.GoToAsync($"{nameof(Views.GroceryListItemsView)}?Titel={groceryList.Name}", true, paramater);
         }
+
+        [RelayCommand]
+        public async Task ShowBoughtProducts()
+        {
+            if (_global.Client?.Role == Role.Admin)
+            {
+                await Shell.Current.GoToAsync(nameof(Views.BoughtProductsView));
+            }
+        }
+
         public override void OnAppearing()
         {
             base.OnAppearing();
             GroceryLists = new(_groceryListService.GetAll());
+            Client = _global.Client;
         }
 
         public override void OnDisappearing()

--- a/Grocery.App/Views/GroceryListsView.xaml
+++ b/Grocery.App/Views/GroceryListsView.xaml
@@ -6,6 +6,9 @@
              xmlns:m="clr-namespace:Grocery.Core.Models;assembly=Grocery.Core"
              x:DataType="vm:GroceryListViewModel"
              Title="GroceryListsView">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="{Binding Client.Name}" Command="{Binding ShowBoughtProductsCommand}" />
+    </ContentPage.ToolbarItems>
     <Shell.TitleView>
         <Grid>
             <Label Text="Boodschappenlijsten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />

--- a/Grocery.Core.Data/Repositories/ClientRepository.cs
+++ b/Grocery.Core.Data/Repositories/ClientRepository.cs
@@ -1,4 +1,5 @@
 ﻿
+using Grocery.Core.Enums;
 using Grocery.Core.Interfaces.Repositories;
 using Grocery.Core.Models;
 
@@ -13,7 +14,7 @@ namespace Grocery.Core.Data.Repositories
             clientList = [
                 new Client(1, "M.J. Curie", "user1@mail.com", "IunRhDKa+fWo8+4/Qfj7Pg==.kDxZnUQHCZun6gLIE6d9oeULLRIuRmxmH2QKJv2IM08="),
                 new Client(2, "H.H. Hermans", "user2@mail.com", "dOk+X+wt+MA9uIniRGKDFg==.QLvy72hdG8nWj1FyL75KoKeu4DUgu5B/HAHqTD2UFLU="),
-                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=")
+                new Client(3, "A.J. Kwak", "user3@mail.com", "sxnIcZdYt8wC8MYWcQVQjQ==.FKd5Z/jwxPv3a63lX+uvQ0+P7EuNYZybvkmdhbnkIHA=", Role.Admin)
             ];
         }
 

--- a/Grocery.Core/Enums/Role.cs
+++ b/Grocery.Core/Enums/Role.cs
@@ -1,0 +1,8 @@
+namespace Grocery.Core.Enums
+{
+    public enum Role
+    {
+        None,
+        Admin
+    }
+}

--- a/Grocery.Core/Models/Client.cs
+++ b/Grocery.Core/Models/Client.cs
@@ -1,14 +1,19 @@
 ﻿
+using Grocery.Core.Enums;
+
 namespace Grocery.Core.Models
 {
     public partial class Client : Model
     {
         public string EmailAddress { get; set; }
         public string Password { get; set; }
-        public Client(int id, string name, string emailAddress, string password) : base(id, name)
+        public Role Role { get; set; } = Role.None;
+
+        public Client(int id, string name, string emailAddress, string password, Role role = Role.None) : base(id, name)
         {
-            EmailAddress=emailAddress;
-            Password=password;
+            EmailAddress = emailAddress;
+            Password = password;
+            Role = role;
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose the current client and admin-only navigation command in the grocery list view model
- add a toolbar item in GroceryListsView that shows the client name and invokes the new command
- introduce a Role enum and assign the admin role to the seeded admin client

## Testing
- `dotnet build Grocery.sln` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc7d497b4832eb38d91b11dbfc9f2