### PR TITLE
Update bought products when selection changes

### DIFF
--- a/Grocery.App/ViewModels/BoughtProductsViewModel.cs
+++ b/Grocery.App/ViewModels/BoughtProductsViewModel.cs
@@ -24,7 +24,19 @@ namespace Grocery.App.ViewModels
 
         partial void OnSelectedProductChanged(Product? oldValue, Product newValue)
         {
-            //Zorg dat de lijst BoughtProductsList met de gegevens die passen bij het geselecteerde product. 
+            BoughtProductsList.Clear();
+
+            if (newValue is null)
+            {
+                return;
+            }
+
+            var boughtProducts = _boughtProductsService.Get(newValue.Id);
+
+            foreach (var boughtProduct in boughtProducts)
+            {
+                BoughtProductsList.Add(boughtProduct);
+            }
         }
 
         [RelayCommand]


### PR DESCRIPTION
## Summary
- clear the bought products list whenever a new product is selected
- guard against null selections when looking up bought products
- populate the list with the service results so the UI updates

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc7d1eebc832ea3f9fa491db4c84c